### PR TITLE
chore: add editor and environment config files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# MyCollections Environment Variables
+# Copy this file to .env and fill in your values
+
+# Server
+HOST=0.0.0.0
+PORT=3000
+NODE_ENV=development

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,42 @@
+# Dependencies
 node_modules
+
+# Build output
 dist
+build
+*.tsbuildinfo
+
+# Turbo
 .turbo
+
+# Test coverage
+coverage
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE / Editor
+.idea
+.vscode/*
+!.vscode/extensions.json
+*.swp
+*.swo
+*~
+
+# Logs
+*.log
+npm-debug.log*
+pnpm-debug.log*
+
+# Tauri (phase 6)
+src-tauri/target
+
+# Misc
+*.tgz
+.cache


### PR DESCRIPTION
## Summary
- Expand `.gitignore` with comprehensive entries (coverage, .env, IDE, OS files, logs, Tauri target)
- Add `.editorconfig` (UTF-8, LF, 2-space indent, trim trailing whitespace)
- Add `.env.example` with minimal server config template

Closes #5

## Test plan
- [ ] `nvm use` picks up Node 24 from `.nvmrc`
- [ ] Editor respects `.editorconfig` settings (verify indent size, line endings)
- [ ] No unwanted files tracked by git (`.env`, `.DS_Store`, `coverage/`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)