### PR TITLE
feat(db): Drizzle schema, auto-migrations with pre-backup, and repository layer

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -4,6 +4,9 @@
   "language": "en",
   "words": [
     "mycollections",
+    "autoincrement",
+    "upsert",
+    "upserts",
     "barcodes",
     "biomejs",
     "depscore",

--- a/packages/core/src/media.test.ts
+++ b/packages/core/src/media.test.ts
@@ -24,4 +24,13 @@ describe("MediaSchema", () => {
   it("rejects unknown kind", () => {
     expect(() => MediaSchema.parse({ ...baseMedia, kind: "video" })).toThrow();
   });
+
+  it("defaults deletedAt to null", () => {
+    expect(MediaSchema.parse(baseMedia).deletedAt).toBeNull();
+  });
+
+  it("accepts a deletedAt timestamp", () => {
+    const parsed = MediaSchema.parse({ ...baseMedia, deletedAt: "2026-05-26T00:00:00.000Z" });
+    expect(parsed.deletedAt).toBe("2026-05-26T00:00:00.000Z");
+  });
 });

--- a/packages/core/src/media.ts
+++ b/packages/core/src/media.ts
@@ -13,6 +13,7 @@ export const MediaSchema = z.object({
   isPrimary: z.boolean(),
   storagePath: z.string().optional(),
   createdAt: z.iso.datetime(),
+  deletedAt: z.iso.datetime().nullable().default(null),
 });
 
 export type Media = z.infer<typeof MediaSchema>;

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,0 +1,54 @@
+# @mycollections/db
+
+Local persistence for MyCollections: a single file-backed SQLite database (WAL mode) accessed through [Drizzle ORM](https://orm.drizzle.team/) and better-sqlite3, exposed to the rest of the app as typed repositories over the [`@mycollections/core`](../core/) domain types.
+
+An earlier draft of this package called for an in-memory SQLite mirror in front of the file database. That was dropped (see #20): WAL-mode SQLite on a local file already answers queries in microseconds at this app's scale, and a single database removes a whole class of divergence bugs. The repository layer is the seam where a cache could be added later if ever measured as needed.
+
+## Schema (Phase 1)
+
+| Table | Purpose |
+|---|---|
+| `collections` | Collection metadata, `is_finite_set` flag, and the field schema (JSON array of `FieldDefinition`) |
+| `items` | Items with `status` (`owned`/`wanted`/`ordered`) and custom field values in a JSON column queryable with `json_extract()` |
+| `media` | Per-item media (images) with primary designation and `storage_path` |
+| `user_profile` | Account info from the auth layer plus a JSON settings blob (theme, locale, opt-outs) |
+
+Later phases add their own tables via new migrations: `share_links` (#48), `plugin_data` (#54/#55), `licenses` (#57), `mutations`/`sync_state` (#49), and the `items_fts` FTS5 table (#41).
+
+- **Soft delete**: `collections`, `items`, and `media` carry a nullable `deleted_at`; repositories exclude soft-deleted rows unless asked (`includeDeleted`), and offer `restore()`. Hard deletes cascade (collection → items → media) via foreign keys.
+- **Timestamps** are ISO 8601 strings, matching the core Zod schemas.
+
+## Migrations
+
+Migrations are generated with drizzle-kit (`pnpm generate`) into `drizzle/` and ship with the package. `openDatabase()` applies pending migrations automatically on startup. If the database already has data and migrations are pending, a backup copy is written next to it first (`<path>.<timestamp>.bak`) — restoring is opening that file.
+
+## Usage
+
+```ts
+import { openDatabase } from "@mycollections/db";
+
+const handle = await openDatabase({ path: "/data/app.db" }); // ":memory:" in tests
+
+const collection = await handle.collections.create({
+  name: "Books",
+  fields: [{ id: "title", type: "text", label: "Title", required: true }],
+  isFiniteSet: false,
+});
+const item = await handle.items.create({ collectionId: collection.id, fields: { title: "Dune" } });
+const hits = await handle.items.findByFieldValue(collection.id, "title", "Dune"); // json_extract()
+
+handle.close();
+```
+
+## What's exported
+
+| Export | Purpose |
+|---|---|
+| `openDatabase` / `DatabaseHandle` | Open + migrate the database; returns repositories, the Drizzle instance (`db`), and the raw connection (`sqlite`) |
+| `CollectionsRepository` | CRUD, soft delete/restore, hard delete |
+| `ItemsRepository` | CRUD, list/filter by status, `findByFieldValue()` via `json_extract()` |
+| `MediaRepository` | CRUD plus `setPrimary()` (demotes the previous primary in the same transaction) |
+| `UserProfileRepository` | `get()` / `upsert()` keyed by the auth layer's account key |
+| `schema` | The Drizzle table definitions, for callers needing custom queries |
+
+Repositories validate reads and writes with the core Zod schemas, so malformed rows fail loudly at the boundary. All tests run against real SQLite (no mocks).

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  dialect: "sqlite",
+  schema: "./src/schema.ts",
+  out: "./drizzle",
+});

--- a/packages/db/drizzle/0000_init.sql
+++ b/packages/db/drizzle/0000_init.sql
@@ -1,0 +1,46 @@
+CREATE TABLE `collections` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`fields` text NOT NULL,
+	`is_finite_set` integer NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	`deleted_at` text
+);
+--> statement-breakpoint
+CREATE TABLE `items` (
+	`id` text PRIMARY KEY NOT NULL,
+	`collection_id` text NOT NULL,
+	`status` text NOT NULL,
+	`fields` text NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	`deleted_at` text,
+	FOREIGN KEY (`collection_id`) REFERENCES `collections`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `media` (
+	`id` text PRIMARY KEY NOT NULL,
+	`item_id` text NOT NULL,
+	`kind` text NOT NULL,
+	`mime_type` text NOT NULL,
+	`bytes` integer NOT NULL,
+	`is_primary` integer NOT NULL,
+	`storage_path` text,
+	`created_at` text NOT NULL,
+	`deleted_at` text,
+	FOREIGN KEY (`item_id`) REFERENCES `items`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `user_profile` (
+	`id` text PRIMARY KEY NOT NULL,
+	`display_name` text NOT NULL,
+	`email` text,
+	`provider` text NOT NULL,
+	`settings` text NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `user_profile_email_idx` ON `user_profile` (`email`);

--- a/packages/db/drizzle/0000_init.sql
+++ b/packages/db/drizzle/0000_init.sql
@@ -20,6 +20,7 @@ CREATE TABLE `items` (
 	FOREIGN KEY (`collection_id`) REFERENCES `collections`(`id`) ON UPDATE no action ON DELETE cascade
 );
 --> statement-breakpoint
+CREATE INDEX `items_collection_id_idx` ON `items` (`collection_id`,`deleted_at`);--> statement-breakpoint
 CREATE TABLE `media` (
 	`id` text PRIMARY KEY NOT NULL,
 	`item_id` text NOT NULL,
@@ -33,6 +34,7 @@ CREATE TABLE `media` (
 	FOREIGN KEY (`item_id`) REFERENCES `items`(`id`) ON UPDATE no action ON DELETE cascade
 );
 --> statement-breakpoint
+CREATE INDEX `media_item_id_idx` ON `media` (`item_id`);--> statement-breakpoint
 CREATE TABLE `user_profile` (
 	`id` text PRIMARY KEY NOT NULL,
 	`display_name` text NOT NULL,

--- a/packages/db/drizzle/meta/0000_snapshot.json
+++ b/packages/db/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,301 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d5e4aaa5-48bf-4ad2-8cf0-d0d2845e7219",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "collections": {
+      "name": "collections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fields": {
+          "name": "fields",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_finite_set": {
+          "name": "is_finite_set",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "items": {
+      "name": "items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fields": {
+          "name": "fields",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "items_collection_id_collections_id_fk": {
+          "name": "items_collection_id_collections_id_fk",
+          "tableFrom": "items",
+          "tableTo": "collections",
+          "columnsFrom": ["collection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_item_id_items_id_fk": {
+          "name": "media_item_id_items_id_fk",
+          "tableFrom": "media",
+          "tableTo": "items",
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profile": {
+      "name": "user_profile",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_profile_email_idx": {
+          "name": "user_profile_email_idx",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/0000_snapshot.json
+++ b/packages/db/drizzle/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "d5e4aaa5-48bf-4ad2-8cf0-d0d2845e7219",
+  "id": "f668b7eb-fdf5-4dd1-9af8-29500037702f",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "collections": {
@@ -123,7 +123,13 @@
           "autoincrement": false
         }
       },
-      "indexes": {},
+      "indexes": {
+        "items_collection_id_idx": {
+          "name": "items_collection_id_idx",
+          "columns": ["collection_id", "deleted_at"],
+          "isUnique": false
+        }
+      },
       "foreignKeys": {
         "items_collection_id_collections_id_fk": {
           "name": "items_collection_id_collections_id_fk",
@@ -206,7 +212,13 @@
           "autoincrement": false
         }
       },
-      "indexes": {},
+      "indexes": {
+        "media_item_id_idx": {
+          "name": "media_item_id_idx",
+          "columns": ["item_id"],
+          "isUnique": false
+        }
+      },
       "foreignKeys": {
         "media_item_id_items_id_fk": {
           "name": "media_item_id_items_id_fk",

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -5,7 +5,7 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1781042366771,
+      "when": 1781043122583,
       "tag": "0000_init",
       "breakpoints": true
     }

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1781042366771,
+      "tag": "0000_init",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -9,13 +9,37 @@
     "url": "https://github.com/solve4it/mycollections.git",
     "directory": "packages/db"
   },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "drizzle",
+    "README.md"
+  ],
   "scripts": {
-    "build": "echo 'No build step yet'",
-    "test": "echo 'No tests yet'",
-    "lint": "echo 'No lint yet'",
-    "typecheck": "echo 'No typecheck yet'"
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check src",
+    "generate": "drizzle-kit generate"
   },
   "dependencies": {
-    "@mycollections/core": "workspace:*"
+    "@mycollections/core": "workspace:*",
+    "better-sqlite3": "^12.10.0",
+    "drizzle-orm": "^0.45.2"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/node": "24.13.0",
+    "drizzle-kit": "^0.31.10",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
   }
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,1 +1,20 @@
-export {};
+export { type DatabaseHandle, type OpenDatabaseOptions, openDatabase } from "./open-database.js";
+export {
+  CollectionsRepository,
+  type CreateCollectionInput,
+  type ReadOptions,
+  type UpdateCollectionInput,
+} from "./repositories/collections.js";
+export {
+  type CreateItemInput,
+  ItemsRepository,
+  type ListItemsOptions,
+  type UpdateItemInput,
+} from "./repositories/items.js";
+export { type CreateMediaInput, MediaRepository } from "./repositories/media.js";
+export {
+  type UpsertUserProfileInput,
+  type UserProfile,
+  UserProfileRepository,
+} from "./repositories/user-profile.js";
+export * as schema from "./schema.js";

--- a/packages/db/src/open-database.test.ts
+++ b/packages/db/src/open-database.test.ts
@@ -1,0 +1,120 @@
+import { cpSync, existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { openDatabase } from "./open-database.js";
+
+const MIGRATIONS = new URL("../drizzle", import.meta.url).pathname;
+
+let tmp: string;
+const tmpDirs: string[] = [];
+
+function makeTmpDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "mycollections-db-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/** Copies the real migrations folder and appends one extra migration to it. */
+function migrationsWithExtra(dir: string): string {
+  const folder = join(dir, "migrations-extra");
+  cpSync(MIGRATIONS, folder, { recursive: true });
+  writeFileSync(join(folder, "0001_extra.sql"), "CREATE TABLE extra_test (id text PRIMARY KEY);\n");
+  const journalPath = join(folder, "meta", "_journal.json");
+  const journal = JSON.parse(readFileSync(journalPath, "utf8"));
+  const last = journal.entries[journal.entries.length - 1];
+  journal.entries.push({ ...last, idx: last.idx + 1, when: last.when + 1, tag: "0001_extra" });
+  writeFileSync(journalPath, JSON.stringify(journal));
+  return folder;
+}
+
+function backupsIn(dir: string): string[] {
+  return readdirSync(dir).filter((f) => f.endsWith(".bak"));
+}
+
+describe("openDatabase", () => {
+  it("runs migrations automatically so all phase-1 tables exist", async () => {
+    const handle = await openDatabase({ path: ":memory:" });
+    const tables = handle.sqlite
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+      .all()
+      .map((r) => (r as { name: string }).name);
+    expect(tables).toEqual(expect.arrayContaining(["collections", "items", "media", "user_profile"]));
+    handle.close();
+  });
+
+  it("enables WAL mode and foreign keys on file databases", async () => {
+    tmp = makeTmpDir();
+    const handle = await openDatabase({ path: join(tmp, "app.db") });
+    expect(handle.sqlite.pragma("journal_mode", { simple: true })).toBe("wal");
+    expect(handle.sqlite.pragma("foreign_keys", { simple: true })).toBe(1);
+    handle.close();
+  });
+
+  it("does not create a backup for a fresh database", async () => {
+    tmp = makeTmpDir();
+    const handle = await openDatabase({ path: join(tmp, "app.db") });
+    handle.close();
+    expect(backupsIn(tmp)).toHaveLength(0);
+  });
+
+  it("does not create a backup when no migrations are pending", async () => {
+    tmp = makeTmpDir();
+    const path = join(tmp, "app.db");
+    (await openDatabase({ path })).close();
+    (await openDatabase({ path })).close();
+    expect(backupsIn(tmp)).toHaveLength(0);
+  });
+
+  it("backs up an existing database before applying pending migrations", async () => {
+    tmp = makeTmpDir();
+    const path = join(tmp, "app.db");
+    (await openDatabase({ path })).close();
+
+    const handle = await openDatabase({ path, migrationsFolder: migrationsWithExtra(tmp) });
+    const hasExtra = handle.sqlite
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'extra_test'")
+      .get();
+    handle.close();
+
+    expect(hasExtra).toBeTruthy();
+    expect(backupsIn(tmp)).toHaveLength(1);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it("does not back up twice for the same migration", async () => {
+    tmp = makeTmpDir();
+    const path = join(tmp, "app.db");
+    (await openDatabase({ path })).close();
+    const folder = migrationsWithExtra(tmp);
+    (await openDatabase({ path, migrationsFolder: folder })).close();
+    (await openDatabase({ path, migrationsFolder: folder })).close();
+    expect(backupsIn(tmp)).toHaveLength(1);
+  });
+
+  it("the pre-migration backup is itself an openable database", async () => {
+    tmp = makeTmpDir();
+    const path = join(tmp, "app.db");
+    const first = await openDatabase({ path });
+    await first.collections.create({
+      name: "Books",
+      fields: [{ id: "title", type: "text", label: "Title", required: true }],
+      isFiniteSet: false,
+    });
+    first.close();
+
+    (await openDatabase({ path, migrationsFolder: migrationsWithExtra(tmp) })).close();
+
+    const [backup] = backupsIn(tmp);
+    expect(backup).toBeDefined();
+    const restored = await openDatabase({ path: join(tmp, backup as string) });
+    expect(await restored.collections.list()).toHaveLength(1);
+    restored.close();
+  });
+});

--- a/packages/db/src/open-database.ts
+++ b/packages/db/src/open-database.ts
@@ -1,0 +1,95 @@
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { type BetterSQLite3Database, drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { CollectionsRepository } from "./repositories/collections.js";
+import { ItemsRepository } from "./repositories/items.js";
+import { MediaRepository } from "./repositories/media.js";
+import { UserProfileRepository } from "./repositories/user-profile.js";
+import * as schema from "./schema.js";
+
+/** Migrations that ship with this package. */
+const DEFAULT_MIGRATIONS_FOLDER = fileURLToPath(new URL("../drizzle", import.meta.url));
+
+export interface OpenDatabaseOptions {
+  /** SQLite file path, or ":memory:" for an ephemeral database (tests). */
+  path: string;
+  /** Override the migrations folder; defaults to the folder shipped with this package. */
+  migrationsFolder?: string;
+}
+
+export interface DatabaseHandle {
+  /** Drizzle query interface, for callers needing queries beyond the repositories. */
+  db: BetterSQLite3Database<typeof schema>;
+  /** Raw better-sqlite3 connection (pragmas, prepared statements, backups). */
+  sqlite: Database.Database;
+  collections: CollectionsRepository;
+  items: ItemsRepository;
+  media: MediaRepository;
+  userProfile: UserProfileRepository;
+  close(): void;
+}
+
+/**
+ * Opens (creating if needed) the application database and migrates it to the
+ * latest schema. If the database already has data and migrations are pending,
+ * a backup copy is written next to it first (`<path>.<timestamp>.bak`).
+ */
+export async function openDatabase(options: OpenDatabaseOptions): Promise<DatabaseHandle> {
+  const { path, migrationsFolder = DEFAULT_MIGRATIONS_FOLDER } = options;
+  const isFile = path !== ":memory:";
+
+  const sqlite = new Database(path);
+  if (isFile) {
+    sqlite.pragma("journal_mode = WAL");
+  }
+  sqlite.pragma("foreign_keys = ON");
+
+  if (isFile && hasUserTables(sqlite) && countPendingMigrations(sqlite, migrationsFolder) > 0) {
+    const timestamp = new Date().toISOString().replaceAll(":", "-");
+    await sqlite.backup(`${path}.${timestamp}.bak`);
+  }
+
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder });
+
+  return {
+    db,
+    sqlite,
+    collections: new CollectionsRepository(db),
+    items: new ItemsRepository(db),
+    media: new MediaRepository(db),
+    userProfile: new UserProfileRepository(db),
+    close: () => sqlite.close(),
+  };
+}
+
+function hasUserTables(sqlite: Database.Database): boolean {
+  const row = sqlite
+    .prepare("SELECT count(*) AS n FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'")
+    .get() as { n: number };
+  return row.n > 0;
+}
+
+/**
+ * Pending = journal entries not yet recorded in drizzle's migrations table.
+ * Counts are sufficient here: drizzle migrations are append-only, and the
+ * migrator itself verifies hashes when it runs.
+ */
+function countPendingMigrations(sqlite: Database.Database, migrationsFolder: string): number {
+  const journalPath = `${migrationsFolder}/meta/_journal.json`;
+  if (!existsSync(journalPath)) {
+    return 0;
+  }
+  const journal = JSON.parse(readFileSync(journalPath, "utf8")) as { entries: unknown[] };
+
+  const migrationsTable = sqlite
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = '__drizzle_migrations'")
+    .get();
+  const applied = migrationsTable
+    ? (sqlite.prepare("SELECT count(*) AS n FROM __drizzle_migrations").get() as { n: number }).n
+    : 0;
+
+  return Math.max(0, journal.entries.length - applied);
+}

--- a/packages/db/src/repositories/collections.test.ts
+++ b/packages/db/src/repositories/collections.test.ts
@@ -1,0 +1,101 @@
+import type { FieldDefinition } from "@mycollections/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type DatabaseHandle, openDatabase } from "../open-database.js";
+
+const fields: FieldDefinition[] = [
+  { id: "title", type: "text", label: "Title", required: true },
+  { id: "pages", type: "number", label: "Pages", required: false },
+];
+
+let handle: DatabaseHandle;
+
+beforeEach(async () => {
+  handle = await openDatabase({ path: ":memory:" });
+});
+
+afterEach(() => {
+  handle.close();
+});
+
+describe("CollectionsRepository", () => {
+  it("creates a collection with generated id and timestamps", async () => {
+    const collection = await handle.collections.create({ name: "Books", fields, isFiniteSet: false });
+    expect(collection.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(collection.name).toBe("Books");
+    expect(collection.fields).toEqual(fields);
+    expect(collection.deletedAt).toBeNull();
+    expect(collection.createdAt).toBe(collection.updatedAt);
+  });
+
+  it("rejects invalid input", async () => {
+    await expect(handle.collections.create({ name: "", fields, isFiniteSet: false })).rejects.toThrow();
+    await expect(handle.collections.create({ name: "X", fields: [], isFiniteSet: false })).rejects.toThrow();
+  });
+
+  it("round-trips through getById", async () => {
+    const created = await handle.collections.create({
+      name: "Coins",
+      description: "State quarters",
+      fields,
+      isFiniteSet: true,
+    });
+    const fetched = await handle.collections.getById(created.id);
+    expect(fetched).toEqual(created);
+  });
+
+  it("returns null for unknown ids", async () => {
+    expect(await handle.collections.getById("00000000-0000-4000-8000-000000000000")).toBeNull();
+  });
+
+  it("lists collections excluding soft-deleted by default", async () => {
+    const a = await handle.collections.create({ name: "A", fields, isFiniteSet: false });
+    await handle.collections.create({ name: "B", fields, isFiniteSet: false });
+    await handle.collections.softDelete(a.id);
+
+    const listed = await handle.collections.list();
+    expect(listed.map((c) => c.name)).toEqual(["B"]);
+
+    const all = await handle.collections.list({ includeDeleted: true });
+    expect(all).toHaveLength(2);
+  });
+
+  it("updates fields and bumps updatedAt", async () => {
+    const created = await handle.collections.create({ name: "Books", fields, isFiniteSet: false });
+    const updated = await handle.collections.update(created.id, { name: "Novels", isFiniteSet: true });
+    expect(updated?.name).toBe("Novels");
+    expect(updated?.isFiniteSet).toBe(true);
+    expect(updated && updated.updatedAt >= created.updatedAt).toBe(true);
+  });
+
+  it("update returns null for unknown ids", async () => {
+    expect(await handle.collections.update("00000000-0000-4000-8000-000000000000", { name: "X" })).toBeNull();
+  });
+
+  it("soft delete hides, restore brings back", async () => {
+    const created = await handle.collections.create({ name: "Books", fields, isFiniteSet: false });
+    expect(await handle.collections.softDelete(created.id)).toBe(true);
+    expect(await handle.collections.getById(created.id)).toBeNull();
+    expect(await handle.collections.getById(created.id, { includeDeleted: true })).not.toBeNull();
+
+    expect(await handle.collections.restore(created.id)).toBe(true);
+    expect((await handle.collections.getById(created.id))?.deletedAt).toBeNull();
+  });
+
+  it("soft delete is idempotent-safe and reports misses", async () => {
+    const created = await handle.collections.create({ name: "Books", fields, isFiniteSet: false });
+    expect(await handle.collections.softDelete(created.id)).toBe(true);
+    expect(await handle.collections.softDelete(created.id)).toBe(false);
+    expect(await handle.collections.softDelete("00000000-0000-4000-8000-000000000000")).toBe(false);
+  });
+
+  it("hard delete removes the row and cascades to items and media", async () => {
+    const collection = await handle.collections.create({ name: "Books", fields, isFiniteSet: false });
+    const item = await handle.items.create({ collectionId: collection.id, fields: { title: "Dune" } });
+    await handle.media.create({ itemId: item.id, kind: "image", mimeType: "image/png", bytes: 10 });
+
+    expect(await handle.collections.hardDelete(collection.id)).toBe(true);
+    expect(await handle.collections.getById(collection.id, { includeDeleted: true })).toBeNull();
+    expect(await handle.items.getById(item.id, { includeDeleted: true })).toBeNull();
+    expect(await handle.media.listByItem(item.id, { includeDeleted: true })).toHaveLength(0);
+  });
+});

--- a/packages/db/src/repositories/collections.ts
+++ b/packages/db/src/repositories/collections.ts
@@ -1,0 +1,120 @@
+import { randomUUID } from "node:crypto";
+import { type Collection, CollectionSchema, type FieldDefinition } from "@mycollections/core";
+import { and, eq, isNotNull, isNull } from "drizzle-orm";
+import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import * as schema from "../schema.js";
+
+type Db = BetterSQLite3Database<typeof schema>;
+type CollectionRow = typeof schema.collections.$inferSelect;
+
+export interface CreateCollectionInput {
+  name: string;
+  description?: string;
+  fields: FieldDefinition[];
+  isFiniteSet: boolean;
+}
+
+export type UpdateCollectionInput = Partial<CreateCollectionInput>;
+
+export interface ReadOptions {
+  includeDeleted?: boolean;
+}
+
+function rowToCollection(row: CollectionRow): Collection {
+  return CollectionSchema.parse({
+    id: row.id,
+    name: row.name,
+    description: row.description ?? undefined,
+    fields: JSON.parse(row.fields),
+    isFiniteSet: row.isFiniteSet,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    deletedAt: row.deletedAt,
+  });
+}
+
+function collectionToRow(collection: Collection): CollectionRow {
+  return {
+    id: collection.id,
+    name: collection.name,
+    description: collection.description ?? null,
+    fields: JSON.stringify(collection.fields),
+    isFiniteSet: collection.isFiniteSet,
+    createdAt: collection.createdAt,
+    updatedAt: collection.updatedAt,
+    deletedAt: collection.deletedAt,
+  };
+}
+
+export class CollectionsRepository {
+  readonly #db: Db;
+
+  constructor(db: Db) {
+    this.#db = db;
+  }
+
+  async create(input: CreateCollectionInput): Promise<Collection> {
+    const now = new Date().toISOString();
+    const collection = CollectionSchema.parse({
+      id: randomUUID(),
+      ...input,
+      createdAt: now,
+      updatedAt: now,
+      deletedAt: null,
+    });
+    this.#db.insert(schema.collections).values(collectionToRow(collection)).run();
+    return collection;
+  }
+
+  async getById(id: string, options: ReadOptions = {}): Promise<Collection | null> {
+    const row = this.#db.select().from(schema.collections).where(eq(schema.collections.id, id)).get();
+    if (!row || (row.deletedAt !== null && !options.includeDeleted)) {
+      return null;
+    }
+    return rowToCollection(row);
+  }
+
+  async list(options: ReadOptions = {}): Promise<Collection[]> {
+    const query = this.#db.select().from(schema.collections);
+    const rows = options.includeDeleted ? query.all() : query.where(isNull(schema.collections.deletedAt)).all();
+    return rows.map(rowToCollection);
+  }
+
+  async update(id: string, patch: UpdateCollectionInput): Promise<Collection | null> {
+    const existing = await this.getById(id, { includeDeleted: true });
+    if (!existing) {
+      return null;
+    }
+    const updated = CollectionSchema.parse({
+      ...existing,
+      ...patch,
+      id,
+      updatedAt: new Date().toISOString(),
+    });
+    this.#db.update(schema.collections).set(collectionToRow(updated)).where(eq(schema.collections.id, id)).run();
+    return updated;
+  }
+
+  async softDelete(id: string): Promise<boolean> {
+    const result = this.#db
+      .update(schema.collections)
+      .set({ deletedAt: new Date().toISOString() })
+      .where(and(eq(schema.collections.id, id), isNull(schema.collections.deletedAt)))
+      .run();
+    return result.changes > 0;
+  }
+
+  async restore(id: string): Promise<boolean> {
+    const result = this.#db
+      .update(schema.collections)
+      .set({ deletedAt: null })
+      .where(and(eq(schema.collections.id, id), isNotNull(schema.collections.deletedAt)))
+      .run();
+    return result.changes > 0;
+  }
+
+  async hardDelete(id: string): Promise<boolean> {
+    const result = this.#db.delete(schema.collections).where(eq(schema.collections.id, id)).run();
+    return result.changes > 0;
+  }
+}

--- a/packages/db/src/repositories/items.test.ts
+++ b/packages/db/src/repositories/items.test.ts
@@ -67,6 +67,15 @@ describe("ItemsRepository", () => {
     expect(await handle.items.findByFieldValue(collection.id, "title", "Missing")).toEqual([]);
   });
 
+  it("findByFieldValue handles field ids containing quotes and backslashes", async () => {
+    const weird = await handle.items.create({
+      collectionId: collection.id,
+      fields: { 'he"said': "yes", "back\\slash": 7 },
+    });
+    expect(await handle.items.findByFieldValue(collection.id, 'he"said', "yes")).toEqual([weird]);
+    expect(await handle.items.findByFieldValue(collection.id, "back\\slash", 7)).toEqual([weird]);
+  });
+
   it("updates status and fields, bumping updatedAt", async () => {
     const created = await handle.items.create({ collectionId: collection.id, status: "wanted", fields: {} });
     const updated = await handle.items.update(created.id, { status: "owned", fields: { title: "Dune" } });

--- a/packages/db/src/repositories/items.test.ts
+++ b/packages/db/src/repositories/items.test.ts
@@ -1,0 +1,94 @@
+import type { Collection, FieldDefinition } from "@mycollections/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type DatabaseHandle, openDatabase } from "../open-database.js";
+
+const fields: FieldDefinition[] = [
+  { id: "title", type: "text", label: "Title", required: true },
+  { id: "pages", type: "number", label: "Pages", required: false },
+];
+
+let handle: DatabaseHandle;
+let collection: Collection;
+
+beforeEach(async () => {
+  handle = await openDatabase({ path: ":memory:" });
+  collection = await handle.collections.create({ name: "Books", fields, isFiniteSet: false });
+});
+
+afterEach(() => {
+  handle.close();
+});
+
+describe("ItemsRepository", () => {
+  it("creates an item defaulting status to owned", async () => {
+    const item = await handle.items.create({ collectionId: collection.id, fields: { title: "Dune", pages: 412 } });
+    expect(item.status).toBe("owned");
+    expect(item.fields).toEqual({ title: "Dune", pages: 412 });
+    expect(item.deletedAt).toBeNull();
+  });
+
+  it("accepts explicit wanted/ordered statuses and rejects unknown ones", async () => {
+    const wanted = await handle.items.create({ collectionId: collection.id, status: "wanted", fields: {} });
+    expect(wanted.status).toBe("wanted");
+    await expect(
+      // @ts-expect-error invalid status must be rejected at runtime too
+      handle.items.create({ collectionId: collection.id, status: "lost", fields: {} }),
+    ).rejects.toThrow();
+  });
+
+  it("rejects items pointing at a missing collection", async () => {
+    await expect(
+      handle.items.create({ collectionId: "00000000-0000-4000-8000-000000000000", fields: {} }),
+    ).rejects.toThrow();
+  });
+
+  it("round-trips through getById", async () => {
+    const created = await handle.items.create({ collectionId: collection.id, fields: { title: "Dune" } });
+    expect(await handle.items.getById(created.id)).toEqual(created);
+  });
+
+  it("lists items by collection, filterable by status, excluding soft-deleted", async () => {
+    const owned = await handle.items.create({ collectionId: collection.id, fields: { title: "A" } });
+    await handle.items.create({ collectionId: collection.id, status: "wanted", fields: { title: "B" } });
+    const deleted = await handle.items.create({ collectionId: collection.id, fields: { title: "C" } });
+    await handle.items.softDelete(deleted.id);
+
+    expect(await handle.items.listByCollection(collection.id)).toHaveLength(2);
+    expect(await handle.items.listByCollection(collection.id, { status: "owned" })).toEqual([owned]);
+    expect(await handle.items.listByCollection(collection.id, { includeDeleted: true })).toHaveLength(3);
+  });
+
+  it("finds items by custom field value via json_extract", async () => {
+    await handle.items.create({ collectionId: collection.id, fields: { title: "Dune", pages: 412 } });
+    const hobbit = await handle.items.create({ collectionId: collection.id, fields: { title: "Hobbit", pages: 310 } });
+
+    expect(await handle.items.findByFieldValue(collection.id, "title", "Hobbit")).toEqual([hobbit]);
+    expect(await handle.items.findByFieldValue(collection.id, "pages", 310)).toEqual([hobbit]);
+    expect(await handle.items.findByFieldValue(collection.id, "title", "Missing")).toEqual([]);
+  });
+
+  it("updates status and fields, bumping updatedAt", async () => {
+    const created = await handle.items.create({ collectionId: collection.id, status: "wanted", fields: {} });
+    const updated = await handle.items.update(created.id, { status: "owned", fields: { title: "Dune" } });
+    expect(updated?.status).toBe("owned");
+    expect(updated?.fields).toEqual({ title: "Dune" });
+    expect(updated && updated.updatedAt >= created.updatedAt).toBe(true);
+  });
+
+  it("soft delete, restore, and hard delete behave like collections", async () => {
+    const created = await handle.items.create({ collectionId: collection.id, fields: {} });
+    expect(await handle.items.softDelete(created.id)).toBe(true);
+    expect(await handle.items.getById(created.id)).toBeNull();
+    expect(await handle.items.restore(created.id)).toBe(true);
+    expect(await handle.items.getById(created.id)).not.toBeNull();
+    expect(await handle.items.hardDelete(created.id)).toBe(true);
+    expect(await handle.items.getById(created.id, { includeDeleted: true })).toBeNull();
+  });
+
+  it("hard delete cascades to media", async () => {
+    const item = await handle.items.create({ collectionId: collection.id, fields: {} });
+    const m = await handle.media.create({ itemId: item.id, kind: "image", mimeType: "image/png", bytes: 5 });
+    await handle.items.hardDelete(item.id);
+    expect(await handle.media.getById(m.id, { includeDeleted: true })).toBeNull();
+  });
+});

--- a/packages/db/src/repositories/items.ts
+++ b/packages/db/src/repositories/items.ts
@@ -1,0 +1,155 @@
+import { randomUUID } from "node:crypto";
+import { type Item, ItemSchema, type ItemStatus } from "@mycollections/core";
+import { and, eq, isNotNull, isNull, sql } from "drizzle-orm";
+import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import * as schema from "../schema.js";
+import type { ReadOptions } from "./collections.js";
+
+type Db = BetterSQLite3Database<typeof schema>;
+type ItemRow = typeof schema.items.$inferSelect;
+
+export interface CreateItemInput {
+  collectionId: string;
+  status?: ItemStatus;
+  fields: Record<string, unknown>;
+}
+
+export interface UpdateItemInput {
+  status?: ItemStatus;
+  fields?: Record<string, unknown>;
+}
+
+export interface ListItemsOptions extends ReadOptions {
+  status?: ItemStatus;
+}
+
+function rowToItem(row: ItemRow): Item {
+  return ItemSchema.parse({
+    id: row.id,
+    collectionId: row.collectionId,
+    status: row.status,
+    fields: JSON.parse(row.fields),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    deletedAt: row.deletedAt,
+  });
+}
+
+function itemToRow(item: Item): ItemRow {
+  return {
+    id: item.id,
+    collectionId: item.collectionId,
+    status: item.status,
+    fields: JSON.stringify(item.fields),
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
+    deletedAt: item.deletedAt,
+  };
+}
+
+export class ItemsRepository {
+  readonly #db: Db;
+
+  constructor(db: Db) {
+    this.#db = db;
+  }
+
+  async create(input: CreateItemInput): Promise<Item> {
+    const now = new Date().toISOString();
+    const item = ItemSchema.parse({
+      id: randomUUID(),
+      collectionId: input.collectionId,
+      status: input.status ?? "owned",
+      fields: input.fields,
+      createdAt: now,
+      updatedAt: now,
+      deletedAt: null,
+    });
+    this.#db.insert(schema.items).values(itemToRow(item)).run();
+    return item;
+  }
+
+  async getById(id: string, options: ReadOptions = {}): Promise<Item | null> {
+    const row = this.#db.select().from(schema.items).where(eq(schema.items.id, id)).get();
+    if (!row || (row.deletedAt !== null && !options.includeDeleted)) {
+      return null;
+    }
+    return rowToItem(row);
+  }
+
+  async listByCollection(collectionId: string, options: ListItemsOptions = {}): Promise<Item[]> {
+    const conditions = [eq(schema.items.collectionId, collectionId)];
+    if (!options.includeDeleted) {
+      conditions.push(isNull(schema.items.deletedAt));
+    }
+    if (options.status) {
+      conditions.push(eq(schema.items.status, options.status));
+    }
+    const rows = this.#db
+      .select()
+      .from(schema.items)
+      .where(and(...conditions))
+      .all();
+    return rows.map(rowToItem);
+  }
+
+  /**
+   * Finds non-deleted items whose custom field equals the given value, using
+   * SQLite's json_extract() over the JSON fields column.
+   */
+  async findByFieldValue(collectionId: string, fieldId: string, value: string | number | boolean): Promise<Item[]> {
+    // JSON booleans come back from json_extract() as integers.
+    const compare = typeof value === "boolean" ? (value ? 1 : 0) : value;
+    const path = `$."${fieldId}"`;
+    const rows = this.#db
+      .select()
+      .from(schema.items)
+      .where(
+        and(
+          eq(schema.items.collectionId, collectionId),
+          isNull(schema.items.deletedAt),
+          sql`json_extract(${schema.items.fields}, ${path}) = ${compare}`,
+        ),
+      )
+      .all();
+    return rows.map(rowToItem);
+  }
+
+  async update(id: string, patch: UpdateItemInput): Promise<Item | null> {
+    const existing = await this.getById(id, { includeDeleted: true });
+    if (!existing) {
+      return null;
+    }
+    const updated = ItemSchema.parse({
+      ...existing,
+      ...patch,
+      id,
+      updatedAt: new Date().toISOString(),
+    });
+    this.#db.update(schema.items).set(itemToRow(updated)).where(eq(schema.items.id, id)).run();
+    return updated;
+  }
+
+  async softDelete(id: string): Promise<boolean> {
+    const result = this.#db
+      .update(schema.items)
+      .set({ deletedAt: new Date().toISOString() })
+      .where(and(eq(schema.items.id, id), isNull(schema.items.deletedAt)))
+      .run();
+    return result.changes > 0;
+  }
+
+  async restore(id: string): Promise<boolean> {
+    const result = this.#db
+      .update(schema.items)
+      .set({ deletedAt: null })
+      .where(and(eq(schema.items.id, id), isNotNull(schema.items.deletedAt)))
+      .run();
+    return result.changes > 0;
+  }
+
+  async hardDelete(id: string): Promise<boolean> {
+    const result = this.#db.delete(schema.items).where(eq(schema.items.id, id)).run();
+    return result.changes > 0;
+  }
+}

--- a/packages/db/src/repositories/items.ts
+++ b/packages/db/src/repositories/items.ts
@@ -100,7 +100,9 @@ export class ItemsRepository {
   async findByFieldValue(collectionId: string, fieldId: string, value: string | number | boolean): Promise<Item[]> {
     // JSON booleans come back from json_extract() as integers.
     const compare = typeof value === "boolean" ? (value ? 1 : 0) : value;
-    const path = `$."${fieldId}"`;
+    // The field id is embedded in a JSON path string literal, so escape per JSON string rules.
+    const escaped = fieldId.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    const path = `$."${escaped}"`;
     const rows = this.#db
       .select()
       .from(schema.items)

--- a/packages/db/src/repositories/media.test.ts
+++ b/packages/db/src/repositories/media.test.ts
@@ -1,0 +1,94 @@
+import type { Item } from "@mycollections/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type DatabaseHandle, openDatabase } from "../open-database.js";
+
+let handle: DatabaseHandle;
+let item: Item;
+
+beforeEach(async () => {
+  handle = await openDatabase({ path: ":memory:" });
+  const collection = await handle.collections.create({
+    name: "Books",
+    fields: [{ id: "title", type: "text", label: "Title", required: true }],
+    isFiniteSet: false,
+  });
+  item = await handle.items.create({ collectionId: collection.id, fields: { title: "Dune" } });
+});
+
+afterEach(() => {
+  handle.close();
+});
+
+describe("MediaRepository", () => {
+  it("creates media with generated id and timestamp", async () => {
+    const media = await handle.media.create({
+      itemId: item.id,
+      kind: "image",
+      mimeType: "image/jpeg",
+      bytes: 1024,
+      storagePath: "media/abc.jpg",
+    });
+    expect(media.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(media.isPrimary).toBe(false);
+    expect(media.storagePath).toBe("media/abc.jpg");
+    expect(media.deletedAt).toBeNull();
+  });
+
+  it("rejects media pointing at a missing item", async () => {
+    await expect(
+      handle.media.create({
+        itemId: "00000000-0000-4000-8000-000000000000",
+        kind: "image",
+        mimeType: "image/png",
+        bytes: 1,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("first media created as primary demotes nothing; later setPrimary swaps", async () => {
+    const a = await handle.media.create({
+      itemId: item.id,
+      kind: "image",
+      mimeType: "image/png",
+      bytes: 1,
+      isPrimary: true,
+    });
+    const b = await handle.media.create({
+      itemId: item.id,
+      kind: "image",
+      mimeType: "image/png",
+      bytes: 2,
+      isPrimary: true,
+    });
+
+    let listed = await handle.media.listByItem(item.id);
+    expect(listed.filter((m) => m.isPrimary).map((m) => m.id)).toEqual([b.id]);
+
+    expect(await handle.media.setPrimary(a.id)).toBe(true);
+    listed = await handle.media.listByItem(item.id);
+    expect(listed.filter((m) => m.isPrimary).map((m) => m.id)).toEqual([a.id]);
+  });
+
+  it("setPrimary returns false for unknown ids", async () => {
+    expect(await handle.media.setPrimary("00000000-0000-4000-8000-000000000000")).toBe(false);
+  });
+
+  it("lists media for an item excluding soft-deleted by default", async () => {
+    const a = await handle.media.create({ itemId: item.id, kind: "image", mimeType: "image/png", bytes: 1 });
+    await handle.media.create({ itemId: item.id, kind: "image", mimeType: "image/png", bytes: 2 });
+    await handle.media.softDelete(a.id);
+
+    expect(await handle.media.listByItem(item.id)).toHaveLength(1);
+    expect(await handle.media.listByItem(item.id, { includeDeleted: true })).toHaveLength(2);
+  });
+
+  it("soft delete, restore, and hard delete", async () => {
+    const media = await handle.media.create({ itemId: item.id, kind: "image", mimeType: "image/png", bytes: 1 });
+    expect(await handle.media.softDelete(media.id)).toBe(true);
+    expect(await handle.media.getById(media.id)).toBeNull();
+    expect(await handle.media.restore(media.id)).toBe(true);
+    expect(await handle.media.getById(media.id)).not.toBeNull();
+    expect(await handle.media.hardDelete(media.id)).toBe(true);
+    expect(await handle.media.getById(media.id, { includeDeleted: true })).toBeNull();
+  });
+});

--- a/packages/db/src/repositories/media.ts
+++ b/packages/db/src/repositories/media.ts
@@ -1,0 +1,133 @@
+import { randomUUID } from "node:crypto";
+import { type Media, MediaSchema } from "@mycollections/core";
+import { and, eq, isNotNull, isNull } from "drizzle-orm";
+import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import * as schema from "../schema.js";
+import type { ReadOptions } from "./collections.js";
+
+type Db = BetterSQLite3Database<typeof schema>;
+type MediaRow = typeof schema.media.$inferSelect;
+type MediaKind = Media["kind"];
+
+export interface CreateMediaInput {
+  itemId: string;
+  kind: MediaKind;
+  mimeType: string;
+  bytes: number;
+  isPrimary?: boolean;
+  storagePath?: string;
+}
+
+function rowToMedia(row: MediaRow): Media {
+  return MediaSchema.parse({
+    id: row.id,
+    itemId: row.itemId,
+    kind: row.kind,
+    mimeType: row.mimeType,
+    bytes: row.bytes,
+    isPrimary: row.isPrimary,
+    storagePath: row.storagePath ?? undefined,
+    createdAt: row.createdAt,
+    deletedAt: row.deletedAt,
+  });
+}
+
+function mediaToRow(media: Media): MediaRow {
+  return {
+    id: media.id,
+    itemId: media.itemId,
+    kind: media.kind,
+    mimeType: media.mimeType,
+    bytes: media.bytes,
+    isPrimary: media.isPrimary,
+    storagePath: media.storagePath ?? null,
+    createdAt: media.createdAt,
+    deletedAt: media.deletedAt,
+  };
+}
+
+export class MediaRepository {
+  readonly #db: Db;
+
+  constructor(db: Db) {
+    this.#db = db;
+  }
+
+  async create(input: CreateMediaInput): Promise<Media> {
+    const media = MediaSchema.parse({
+      id: randomUUID(),
+      itemId: input.itemId,
+      kind: input.kind,
+      mimeType: input.mimeType,
+      bytes: input.bytes,
+      isPrimary: input.isPrimary ?? false,
+      storagePath: input.storagePath,
+      createdAt: new Date().toISOString(),
+      deletedAt: null,
+    });
+    this.#db.transaction((tx) => {
+      if (media.isPrimary) {
+        tx.update(schema.media).set({ isPrimary: false }).where(eq(schema.media.itemId, media.itemId)).run();
+      }
+      tx.insert(schema.media).values(mediaToRow(media)).run();
+    });
+    return media;
+  }
+
+  async getById(id: string, options: ReadOptions = {}): Promise<Media | null> {
+    const row = this.#db.select().from(schema.media).where(eq(schema.media.id, id)).get();
+    if (!row || (row.deletedAt !== null && !options.includeDeleted)) {
+      return null;
+    }
+    return rowToMedia(row);
+  }
+
+  async listByItem(itemId: string, options: ReadOptions = {}): Promise<Media[]> {
+    const conditions = [eq(schema.media.itemId, itemId)];
+    if (!options.includeDeleted) {
+      conditions.push(isNull(schema.media.deletedAt));
+    }
+    const rows = this.#db
+      .select()
+      .from(schema.media)
+      .where(and(...conditions))
+      .all();
+    return rows.map(rowToMedia);
+  }
+
+  /** Makes this media the item's primary image, demoting any current primary. */
+  async setPrimary(id: string): Promise<boolean> {
+    const row = this.#db.select().from(schema.media).where(eq(schema.media.id, id)).get();
+    if (!row) {
+      return false;
+    }
+    this.#db.transaction((tx) => {
+      tx.update(schema.media).set({ isPrimary: false }).where(eq(schema.media.itemId, row.itemId)).run();
+      tx.update(schema.media).set({ isPrimary: true }).where(eq(schema.media.id, id)).run();
+    });
+    return true;
+  }
+
+  async softDelete(id: string): Promise<boolean> {
+    const result = this.#db
+      .update(schema.media)
+      .set({ deletedAt: new Date().toISOString() })
+      .where(and(eq(schema.media.id, id), isNull(schema.media.deletedAt)))
+      .run();
+    return result.changes > 0;
+  }
+
+  async restore(id: string): Promise<boolean> {
+    const result = this.#db
+      .update(schema.media)
+      .set({ deletedAt: null })
+      .where(and(eq(schema.media.id, id), isNotNull(schema.media.deletedAt)))
+      .run();
+    return result.changes > 0;
+  }
+
+  async hardDelete(id: string): Promise<boolean> {
+    const result = this.#db.delete(schema.media).where(eq(schema.media.id, id)).run();
+    return result.changes > 0;
+  }
+}

--- a/packages/db/src/repositories/user-profile.test.ts
+++ b/packages/db/src/repositories/user-profile.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type DatabaseHandle, openDatabase } from "../open-database.js";
+
+let handle: DatabaseHandle;
+
+beforeEach(async () => {
+  handle = await openDatabase({ path: ":memory:" });
+});
+
+afterEach(() => {
+  handle.close();
+});
+
+describe("UserProfileRepository", () => {
+  it("returns null when no profile is stored", async () => {
+    expect(await handle.userProfile.get("oidc:sub-1")).toBeNull();
+  });
+
+  it("creates a profile on first upsert", async () => {
+    const profile = await handle.userProfile.upsert({
+      id: "oidc:sub-1",
+      displayName: "Sam",
+      email: "sam@example.com",
+      provider: "oidc",
+      settings: { theme: "dark", locale: "en-US" },
+    });
+    expect(profile.createdAt).toBe(profile.updatedAt);
+    expect(await handle.userProfile.get("oidc:sub-1")).toEqual(profile);
+  });
+
+  it("updates in place on subsequent upserts, preserving createdAt", async () => {
+    const first = await handle.userProfile.upsert({
+      id: "oidc:sub-1",
+      displayName: "Sam",
+      provider: "oidc",
+      settings: {},
+    });
+    const second = await handle.userProfile.upsert({
+      id: "oidc:sub-1",
+      displayName: "Samantha",
+      provider: "oidc",
+      settings: { theme: "light" },
+    });
+    expect(second.displayName).toBe("Samantha");
+    expect(second.settings).toEqual({ theme: "light" });
+    expect(second.createdAt).toBe(first.createdAt);
+    expect(second.updatedAt >= first.updatedAt).toBe(true);
+  });
+
+  it("stores email as null when omitted", async () => {
+    const profile = await handle.userProfile.upsert({
+      id: "oidc:sub-2",
+      displayName: "NoMail",
+      provider: "oidc",
+      settings: {},
+    });
+    expect(profile.email).toBeNull();
+  });
+});

--- a/packages/db/src/repositories/user-profile.ts
+++ b/packages/db/src/repositories/user-profile.ts
@@ -1,0 +1,72 @@
+import { eq } from "drizzle-orm";
+import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import * as schema from "../schema.js";
+
+type Db = BetterSQLite3Database<typeof schema>;
+type UserProfileRow = typeof schema.userProfile.$inferSelect;
+
+export interface UserProfile {
+  /** Opaque account key from the auth layer (e.g. `${providerId}:${sub}`). */
+  id: string;
+  displayName: string;
+  email: string | null;
+  provider: string;
+  /** User preferences (theme, locale, opt-outs, ...). */
+  settings: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpsertUserProfileInput {
+  id: string;
+  displayName: string;
+  email?: string;
+  provider: string;
+  settings: Record<string, unknown>;
+}
+
+function rowToProfile(row: UserProfileRow): UserProfile {
+  return {
+    id: row.id,
+    displayName: row.displayName,
+    email: row.email,
+    provider: row.provider,
+    settings: JSON.parse(row.settings),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export class UserProfileRepository {
+  readonly #db: Db;
+
+  constructor(db: Db) {
+    this.#db = db;
+  }
+
+  async get(id: string): Promise<UserProfile | null> {
+    const row = this.#db.select().from(schema.userProfile).where(eq(schema.userProfile.id, id)).get();
+    return row ? rowToProfile(row) : null;
+  }
+
+  async upsert(input: UpsertUserProfileInput): Promise<UserProfile> {
+    const now = new Date().toISOString();
+    const existing = await this.get(input.id);
+    const profile: UserProfile = {
+      id: input.id,
+      displayName: input.displayName,
+      email: input.email ?? null,
+      provider: input.provider,
+      settings: input.settings,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+    const row = { ...profile, settings: JSON.stringify(profile.settings) };
+    this.#db
+      .insert(schema.userProfile)
+      .values(row)
+      .onConflictDoUpdate({ target: schema.userProfile.id, set: row })
+      .run();
+    return profile;
+  }
+}

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,0 +1,65 @@
+import { integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+
+/**
+ * Phase 1 tables only. Later phases add their own tables via new migrations:
+ * share_links (#48), plugin_data (#54/#55), licenses (#57),
+ * mutations/sync_state (#49), items_fts (#41).
+ *
+ * Timestamps are ISO 8601 strings to match the core Zod schemas. Custom field
+ * values live in JSON text columns queryable with json_extract().
+ */
+
+export const collections = sqliteTable("collections", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  description: text("description"),
+  /** JSON array of FieldDefinition. */
+  fields: text("fields").notNull(),
+  isFiniteSet: integer("is_finite_set", { mode: "boolean" }).notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+  deletedAt: text("deleted_at"),
+});
+
+export const items = sqliteTable("items", {
+  id: text("id").primaryKey(),
+  collectionId: text("collection_id")
+    .notNull()
+    .references(() => collections.id, { onDelete: "cascade" }),
+  status: text("status").notNull(),
+  /** JSON object mapping field id -> value, queryable with json_extract(). */
+  fields: text("fields").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+  deletedAt: text("deleted_at"),
+});
+
+export const media = sqliteTable("media", {
+  id: text("id").primaryKey(),
+  itemId: text("item_id")
+    .notNull()
+    .references(() => items.id, { onDelete: "cascade" }),
+  kind: text("kind").notNull(),
+  mimeType: text("mime_type").notNull(),
+  bytes: integer("bytes").notNull(),
+  isPrimary: integer("is_primary", { mode: "boolean" }).notNull(),
+  storagePath: text("storage_path"),
+  createdAt: text("created_at").notNull(),
+  deletedAt: text("deleted_at"),
+});
+
+export const userProfile = sqliteTable(
+  "user_profile",
+  {
+    /** Opaque account key from the auth layer (e.g. `${providerId}:${sub}`). */
+    id: text("id").primaryKey(),
+    displayName: text("display_name").notNull(),
+    email: text("email"),
+    provider: text("provider").notNull(),
+    /** JSON object for user preferences (theme, locale, opt-outs, ...). */
+    settings: text("settings").notNull(),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [uniqueIndex("user_profile_email_idx").on(table.email)],
+);

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,4 +1,4 @@
-import { integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+import { index, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 
 /**
  * Phase 1 tables only. Later phases add their own tables via new migrations:
@@ -21,32 +21,40 @@ export const collections = sqliteTable("collections", {
   deletedAt: text("deleted_at"),
 });
 
-export const items = sqliteTable("items", {
-  id: text("id").primaryKey(),
-  collectionId: text("collection_id")
-    .notNull()
-    .references(() => collections.id, { onDelete: "cascade" }),
-  status: text("status").notNull(),
-  /** JSON object mapping field id -> value, queryable with json_extract(). */
-  fields: text("fields").notNull(),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-  deletedAt: text("deleted_at"),
-});
+export const items = sqliteTable(
+  "items",
+  {
+    id: text("id").primaryKey(),
+    collectionId: text("collection_id")
+      .notNull()
+      .references(() => collections.id, { onDelete: "cascade" }),
+    status: text("status").notNull(),
+    /** JSON object mapping field id -> value, queryable with json_extract(). */
+    fields: text("fields").notNull(),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [index("items_collection_id_idx").on(table.collectionId, table.deletedAt)],
+);
 
-export const media = sqliteTable("media", {
-  id: text("id").primaryKey(),
-  itemId: text("item_id")
-    .notNull()
-    .references(() => items.id, { onDelete: "cascade" }),
-  kind: text("kind").notNull(),
-  mimeType: text("mime_type").notNull(),
-  bytes: integer("bytes").notNull(),
-  isPrimary: integer("is_primary", { mode: "boolean" }).notNull(),
-  storagePath: text("storage_path"),
-  createdAt: text("created_at").notNull(),
-  deletedAt: text("deleted_at"),
-});
+export const media = sqliteTable(
+  "media",
+  {
+    id: text("id").primaryKey(),
+    itemId: text("item_id")
+      .notNull()
+      .references(() => items.id, { onDelete: "cascade" }),
+    kind: text("kind").notNull(),
+    mimeType: text("mime_type").notNull(),
+    bytes: integer("bytes").notNull(),
+    isPrimary: integer("is_primary", { mode: "boolean" }).notNull(),
+    storagePath: text("storage_path"),
+    createdAt: text("created_at").notNull(),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [index("media_item_id_idx").on(table.itemId)],
+);
 
 export const userProfile = sqliteTable(
   "user_profile",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@24.13.0)(vite@7.3.5(@types/node@24.13.0)(jiti@2.6.1)(yaml@2.9.0))
+        version: 4.1.8(@types/node@24.13.0)(vite@7.3.5(@types/node@24.13.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/api:
     dependencies:
@@ -55,10 +55,10 @@ importers:
     dependencies:
       '@astrojs/starlight':
         specifier: ^0.39.3
-        version: 0.39.3(astro@6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(yaml@2.9.0))(typescript@6.0.3)
+        version: 0.39.3(astro@6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))(typescript@6.0.3)
       astro:
         specifier: ^6.4.4
-        version: 6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(yaml@2.9.0)
+        version: 6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0)
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -90,7 +90,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@24.13.0)(vite@7.3.5(@types/node@24.13.0)(jiti@2.6.1)(yaml@2.9.0))
+        version: 4.1.8(@types/node@24.13.0)(vite@7.3.5(@types/node@24.13.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/core:
     dependencies:
@@ -103,13 +103,35 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@24.13.0)(vite@7.3.5(@types/node@24.13.0)(jiti@2.6.1)(yaml@2.9.0))
+        version: 4.1.8(@types/node@24.13.0)(vite@7.3.5(@types/node@24.13.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/db:
     dependencies:
       '@mycollections/core':
         specifier: workspace:*
         version: link:../core
+      better-sqlite3:
+        specifier: ^12.10.0
+        version: 12.10.0
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      '@types/node':
+        specifier: 24.13.0
+        version: 24.13.0
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@24.13.0)(vite@7.3.5(@types/node@24.13.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/lookup:
     dependencies:
@@ -613,6 +635,9 @@ packages:
     resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
     engines: {node: '>=14'}
 
+  '@drizzle-team/brocli@0.10.2':
+    resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
   '@emmetio/abbreviation@2.3.3':
     resolution: {integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==}
 
@@ -637,16 +662,66 @@ packages:
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
+  '@esbuild-kit/core-utils@3.3.2':
+    resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.18.20':
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.18.20':
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.7':
@@ -655,16 +730,70 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.18.20':
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.18.20':
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.18.20':
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.7':
@@ -673,10 +802,46 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.18.20':
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.18.20':
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -685,10 +850,46 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.18.20':
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.18.20':
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.7':
@@ -697,10 +898,46 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.18.20':
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.18.20':
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.7':
@@ -709,10 +946,46 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.18.20':
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.18.20':
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -721,10 +994,46 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.18.20':
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.18.20':
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.7':
@@ -733,16 +1042,64 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.18.20':
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.7':
     resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.18.20':
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.7':
@@ -751,10 +1108,40 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.18.20':
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -763,11 +1150,41 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.18.20':
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
@@ -775,10 +1192,46 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.18.20':
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.18.20':
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-ia32@0.27.7':
@@ -787,8 +1240,32 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.18.20':
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.7':
     resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1224,6 +1701,9 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1416,14 +1896,33 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   bcp-47-match@2.0.3:
     resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
 
   bcp-47@2.1.0:
     resolution: {integrity: sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w==}
 
+  better-sqlite3@12.10.0:
+    resolution: {integrity: sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -1463,6 +1962,9 @@ packages:
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
@@ -1643,6 +2145,14 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
@@ -1688,6 +2198,102 @@ packages:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
 
+  drizzle-kit@0.31.10:
+    resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
+    hasBin: true
+
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
   dset@3.1.4:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
@@ -1700,6 +2306,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -1736,8 +2345,23 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
+  esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1781,6 +2405,10 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1822,6 +2450,9 @@ packages:
       picomatch:
         optional: true
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
@@ -1835,6 +2466,9 @@ packages:
   fontkitten@1.0.3:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1853,6 +2487,9 @@ packages:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
 
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
   get-tsconfig@5.0.0-beta.4:
     resolution: {integrity: sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==}
     engines: {node: '>=20.20.0'}
@@ -1861,6 +2498,9 @@ packages:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -1957,6 +2597,9 @@ packages:
       typescript:
         optional: true
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -1967,6 +2610,12 @@ packages:
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ini@6.0.0:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
@@ -2275,6 +2924,16 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -2290,12 +2949,19 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   neotraverse@0.6.18:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
     engines: {node: '>= 10'}
 
   nlcst-to-string@4.0.0:
     resolution: {integrity: sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==}
+
+  node-abi@3.92.0:
+    resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
+    engines: {node: '>=10'}
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
@@ -2319,6 +2985,9 @@ packages:
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -2400,6 +3069,12 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prettier@3.8.3:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
@@ -2412,8 +3087,19 @@ packages:
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -2538,6 +3224,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
@@ -2562,6 +3251,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -2584,6 +3279,13 @@ packages:
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   source-map@0.7.6:
@@ -2618,6 +3320,9 @@ packages:
     resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
     engines: {node: '>=20'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
@@ -2629,6 +3334,10 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -2639,6 +3348,13 @@ packages:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
     engines: {node: '>=16'}
     hasBin: true
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
@@ -2670,6 +3386,14 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   turbo@2.9.16:
     resolution: {integrity: sha512-NqgRQy6j6dPYcdSdv0q1g9QsZg7SWg87RERM8otw/1AtKU2yTFVClOM7cbwKzOonZr/Ek1blTBucw64L9H0Bwg==}
@@ -3023,6 +3747,9 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   xdg-basedir@5.1.0:
     resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
     engines: {node: '>=12'}
@@ -3179,12 +3906,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.6(astro@6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(yaml@2.9.0))':
+  '@astrojs/mdx@5.0.6(astro@6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.2
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(yaml@2.9.0)
+      astro: 6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -3208,17 +3935,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.3
 
-  '@astrojs/starlight@0.39.3(astro@6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(yaml@2.9.0))(typescript@6.0.3)':
+  '@astrojs/starlight@0.39.3(astro@6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))(typescript@6.0.3)':
     dependencies:
       '@astrojs/markdown-remark': 7.2.0
-      '@astrojs/mdx': 5.0.6(astro@6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(yaml@2.9.0))
+      '@astrojs/mdx': 5.0.6(astro@6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))
       '@astrojs/sitemap': 3.7.3
       '@pagefind/default-ui': 1.5.2
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(yaml@2.9.0)
-      astro-expressive-code: 0.42.0(astro@6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(yaml@2.9.0))
+      astro: 6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0)
+      astro-expressive-code: 0.42.0(astro@6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -3665,6 +4392,8 @@ snapshots:
 
   '@ctrl/tinycolor@4.2.0': {}
 
+  '@drizzle-team/brocli@0.10.2': {}
+
   '@emmetio/abbreviation@2.3.3':
     dependencies:
       '@emmetio/scanner': 1.0.4
@@ -3693,82 +4422,314 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild-kit/core-utils@3.3.2':
+    dependencies:
+      esbuild: 0.18.20
+      source-map-support: 0.5.21
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    dependencies:
+      '@esbuild-kit/core-utils': 3.3.2
+      get-tsconfig: 4.14.0
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
+  '@esbuild/android-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.18.20':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
     optional: true
 
+  '@esbuild/android-x64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-x64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
+  '@esbuild/linux-loong64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.18.20':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/linux-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.18.20':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
     optional: true
 
+  '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.18.20':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.18.20':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
   '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@expressive-code/core@0.42.0':
@@ -4098,6 +5059,10 @@ snapshots:
   '@turbo/windows-arm64@2.9.16':
     optional: true
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 24.13.0
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -4156,13 +5121,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@7.3.5(@types/node@24.13.0)(jiti@2.6.1)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(vite@7.3.5(@types/node@24.13.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.5(@types/node@24.13.0)(jiti@2.6.1)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@24.13.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -4290,12 +5255,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.42.0(astro@6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(yaml@2.9.0)):
+  astro-expressive-code@0.42.0(astro@6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
-      astro: 6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(yaml@2.9.0)
+      astro: 6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0)
       rehype-expressive-code: 0.42.0
 
-  astro@6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(yaml@2.9.0):
+  astro@6.4.4(@types/node@24.13.0)(jiti@2.6.1)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@astrojs/internal-helpers': 0.10.0
@@ -4347,8 +5312,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 7.3.5(@types/node@24.13.0)(jiti@2.6.1)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@7.3.5(@types/node@24.13.0)(jiti@2.6.1)(yaml@2.9.0))
+      vite: 7.3.5(@types/node@24.13.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@7.3.5(@types/node@24.13.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.3
@@ -4392,6 +5357,8 @@ snapshots:
 
   bail@2.0.2: {}
 
+  base64-js@1.5.1: {}
+
   bcp-47-match@2.0.3: {}
 
   bcp-47@2.1.0:
@@ -4400,7 +5367,29 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
 
+  better-sqlite3@12.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   boolbase@1.0.0: {}
+
+  buffer-from@1.1.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   callsites@3.1.0: {}
 
@@ -4429,6 +5418,8 @@ snapshots:
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  chownr@1.1.4: {}
 
   ci-info@4.4.0: {}
 
@@ -4646,6 +5637,12 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
   defu@6.1.7: {}
 
   dequal@2.0.3: {}
@@ -4686,6 +5683,18 @@ snapshots:
     dependencies:
       is-obj: 2.0.0
 
+  drizzle-kit@0.31.10:
+    dependencies:
+      '@drizzle-team/brocli': 0.10.2
+      '@esbuild-kit/esm-loader': 2.6.5
+      esbuild: 0.25.12
+      tsx: 4.22.4
+
+  drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0):
+    optionalDependencies:
+      '@types/better-sqlite3': 7.6.13
+      better-sqlite3: 12.10.0
+
   dset@3.1.4: {}
 
   emmet@2.4.11:
@@ -4696,6 +5705,10 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   entities@4.5.0: {}
 
@@ -4731,6 +5744,60 @@ snapshots:
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
+  esbuild@0.18.20:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
   esbuild@0.27.7:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.7
@@ -4759,6 +5826,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.7
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
 
   escalade@3.2.0: {}
 
@@ -4803,6 +5899,8 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
 
   expressive-code@0.42.0:
@@ -4836,6 +5934,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  file-uri-to-path@1.0.0: {}
+
   flatted@3.4.2: {}
 
   flattie@1.1.1: {}
@@ -4848,6 +5948,8 @@ snapshots:
     dependencies:
       tiny-inflate: 1.0.3
 
+  fs-constants@1.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
@@ -4856,6 +5958,10 @@ snapshots:
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.6.0: {}
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   get-tsconfig@5.0.0-beta.4:
     dependencies:
@@ -4868,6 +5974,8 @@ snapshots:
     transitivePeerDependencies:
       - conventional-commits-filter
       - conventional-commits-parser
+
+  github-from-package@0.0.0: {}
 
   github-slugger@2.0.0: {}
 
@@ -5090,6 +6198,8 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  ieee754@1.2.1: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -5098,6 +6208,10 @@ snapshots:
   import-fresh@4.0.0: {}
 
   import-meta-resolve@4.2.0: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   ini@6.0.0: {}
 
@@ -5672,6 +6786,12 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  mimic-response@3.1.0: {}
+
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
+
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
@@ -5680,11 +6800,17 @@ snapshots:
 
   nanoid@3.3.12: {}
 
+  napi-build-utils@2.0.0: {}
+
   neotraverse@0.6.18: {}
 
   nlcst-to-string@4.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
+
+  node-abi@3.92.0:
+    dependencies:
+      semver: 7.8.2
 
   node-fetch-native@1.6.7: {}
 
@@ -5705,6 +6831,10 @@ snapshots:
       ufo: 1.6.4
 
   ohash@2.0.11: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   onetime@7.0.0:
     dependencies:
@@ -5803,13 +6933,46 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.92.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   prettier@3.8.3: {}
 
   prismjs@1.30.0: {}
 
   property-information@7.2.0: {}
 
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   radix3@1.1.2: {}
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
 
@@ -6030,6 +7193,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.61.1
       fsevents: 2.3.3
 
+  safe-buffer@5.2.1: {}
+
   sax@1.6.0: {}
 
   semver@7.8.2: {}
@@ -6080,6 +7245,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   sisteransi@1.0.5: {}
 
   sitemap@9.0.1:
@@ -6102,6 +7275,13 @@ snapshots:
   smol-toml@1.6.1: {}
 
   source-map-js@1.2.1: {}
+
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
 
   source-map@0.7.6: {}
 
@@ -6132,6 +7312,10 @@ snapshots:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
@@ -6144,6 +7328,8 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
+
+  strip-json-comments@2.0.1: {}
 
   style-to-js@1.1.21:
     dependencies:
@@ -6162,6 +7348,21 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
       sax: 1.6.0
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   tiny-inflate@1.0.3: {}
 
@@ -6184,6 +7385,16 @@ snapshots:
 
   tslib@2.8.1:
     optional: true
+
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   turbo@2.9.16:
     optionalDependencies:
@@ -6300,7 +7511,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.5(@types/node@24.13.0)(jiti@2.6.1)(yaml@2.9.0):
+  vite@7.3.5(@types/node@24.13.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -6312,16 +7523,17 @@ snapshots:
       '@types/node': 24.13.0
       fsevents: 2.3.3
       jiti: 2.6.1
+      tsx: 4.22.4
       yaml: 2.9.0
 
-  vitefu@1.1.3(vite@7.3.5(@types/node@24.13.0)(jiti@2.6.1)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@7.3.5(@types/node@24.13.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 7.3.5(@types/node@24.13.0)(jiti@2.6.1)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@24.13.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
 
-  vitest@4.1.8(@types/node@24.13.0)(vite@7.3.5(@types/node@24.13.0)(jiti@2.6.1)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@24.13.0)(vite@7.3.5(@types/node@24.13.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@24.13.0)(jiti@2.6.1)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@24.13.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -6338,7 +7550,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@24.13.0)(jiti@2.6.1)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@24.13.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.0
@@ -6477,6 +7689,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  wrappy@1.0.2: {}
 
   xdg-basedir@5.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - "plugins/*"
 
 allowBuilds:
+  better-sqlite3: true
   esbuild: true
   sharp: true
 


### PR DESCRIPTION
Closes #20

## What

Implements `packages/db` per the amended scope of #20 (agreed before implementation — see the issue body for the rationale):

- **Single file-backed SQLite (WAL mode)** via Drizzle ORM + better-sqlite3 — the in-memory mirror from the original spec was dropped as premature optimization.
- **Phase 1 schema only**: `collections` (with `isFiniteSet`), `items` (with `status`), `media`, `user_profile`. Phase 3–5 tables deferred to #48, #54/#55, #57, #49; FTS5 deferred to #41 where it was already listed.
- **`openDatabase()`**: auto-runs pending migrations on startup; when an existing database has pending migrations, a `<path>.<timestamp>.bak` backup is written first (verified by a test that restores from the backup).
- **Typed repositories** over the `@mycollections/core` domain types: CRUD, soft delete/restore (`deletedAt`), hard delete with FK cascade (collection → items → media), `includeDeleted` opt-in reads, `items.findByFieldValue()` via `json_extract()`, `media.setPrimary()` (transactional demote), `userProfile.upsert()`.
- **Core change**: `MediaSchema` gains `deletedAt` (media soft delete is in #20's scope; collections/items already had it).
- Indexes on `items(collection_id, deleted_at)` and `media(item_id)`; field ids are escaped before embedding in `json_extract()` JSON paths (regression-tested).

## Testing

TDD: failing tests committed before implementation. 37 tests in `packages/db` against real SQLite (no mocks), covering migrations, WAL/foreign-key pragmas, pre-migration backup behavior (fresh DB, no-pending, pending, idempotency, backup restorability), and all repository methods. Full workspace `pnpm check` green (33/33 tasks).

## Docs

- New `packages/db/README.md` (schema, migrations/backup, usage, exports).
- `cspell.json` words and `pnpm-workspace.yaml` `allowBuilds` for better-sqlite3 (placeholder was already staged for this).
- No changes needed to root README/CONTRIBUTING/DEVELOPMENT — they don't enumerate per-package internals.

## Notes

- Branch is the remote session branch (`claude/next-priorities-wb3m9j`) rather than a `feat/issue-20-*` branch — this environment can only push there.
- Socket flags better-sqlite3/drizzle-orm as "obfuscated" — that's their minified published dist; triage comment left to the repo owner.

https://claude.ai/code/session_01U2YqtY5WMPJrnWDRVVFeSo