### PR TITLE
fix(docs): copy shared assets recursively #295

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -19,7 +19,7 @@
     "preview": "astro preview",
     "typecheck": "astro check",
     "lint": "echo 'No lint yet'",
-    "test": "echo 'No tests yet'"
+    "test": "node --test scripts/*.test.mjs"
   },
   "dependencies": {
     "@astrojs/markdown-satteri": "^0.4.0",

--- a/apps/docs/scripts/copy-shared-docs.mjs
+++ b/apps/docs/scripts/copy-shared-docs.mjs
@@ -8,14 +8,37 @@ const SRC = resolve(__dirname, "../../../docs");
 const DEST = resolve(__dirname, "../src/content/docs/user");
 const SKIP = new Set(["README.md"]);
 
-await rm(DEST, { recursive: true, force: true });
-await mkdir(DEST, { recursive: true });
-
-const entries = await readdir(SRC, { withFileTypes: true });
-let copied = 0;
-for (const entry of entries) {
-  if (!entry.isFile() || !entry.name.endsWith(".md") || SKIP.has(entry.name)) continue;
-  await copyFile(join(SRC, entry.name), join(DEST, entry.name));
-  copied++;
+async function copyDirectory(src, dest) {
+  await mkdir(dest, { recursive: true });
+  let copied = 0;
+  for (const entry of await readdir(src, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      copied += await copyDirectory(join(src, entry.name), join(dest, entry.name));
+    } else if (entry.isFile()) {
+      await copyFile(join(src, entry.name), join(dest, entry.name));
+      copied++;
+    }
+  }
+  return copied;
 }
-console.log(`[copy-shared-docs] copied ${copied} file(s) from ${SRC} to ${DEST}`);
+
+export async function copySharedDocs(src = SRC, dest = DEST) {
+  await rm(dest, { recursive: true, force: true });
+  await mkdir(dest, { recursive: true });
+
+  let copied = 0;
+  for (const entry of await readdir(src, { withFileTypes: true })) {
+    if (entry.isDirectory() && entry.name === "assets") {
+      copied += await copyDirectory(join(src, entry.name), join(dest, entry.name));
+    } else if (entry.isFile() && entry.name.endsWith(".md") && !SKIP.has(entry.name)) {
+      await copyFile(join(src, entry.name), join(dest, entry.name));
+      copied++;
+    }
+  }
+  return copied;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const copied = await copySharedDocs();
+  console.log(`[copy-shared-docs] copied ${copied} file(s) from ${SRC} to ${DEST}`);
+}

--- a/apps/docs/scripts/copy-shared-docs.test.mjs
+++ b/apps/docs/scripts/copy-shared-docs.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { copySharedDocs } from "./copy-shared-docs.mjs";
+
+test("copies Markdown and nested shared-doc assets", async () => {
+  const root = await mkdtemp(join(tmpdir(), "copy-shared-docs-"));
+  const src = join(root, "docs");
+  const dest = join(root, "generated");
+
+  try {
+    await mkdir(join(src, "assets", "screenshots"), { recursive: true });
+    await writeFile(join(src, "guide.md"), "![UI](./assets/screenshots/ui.svg)");
+    await writeFile(join(src, "README.md"), "source-only instructions");
+    await writeFile(join(src, "assets", "screenshots", "ui.svg"), "<svg></svg>");
+
+    await copySharedDocs(src, dest);
+
+    assert.equal(await readFile(join(dest, "guide.md"), "utf8"), "![UI](./assets/screenshots/ui.svg)");
+    assert.equal(await readFile(join(dest, "assets", "screenshots", "ui.svg"), "utf8"), "<svg></svg>");
+    await assert.rejects(readFile(join(dest, "README.md"), "utf8"), { code: "ENOENT" });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Recursively copy `docs/assets/` beside the generated shared Markdown while preserving the existing top-level Markdown filter. A Node test covers nested assets and the README exclusion.

Validation: `pnpm test`, `pnpm typecheck`, `pnpm lint`, `pnpm spellcheck`, and docs build on Node 24.20. No documentation text changed because this makes the existing documented contract true.

AI-assisted. Closes #295
